### PR TITLE
Fixup bug in argument evaluation in adcconf.c

### DIFF
--- a/robot/adcconf.c
+++ b/robot/adcconf.c
@@ -6,7 +6,7 @@
 #include "coding_wheels.h"
 
 // sample to battery voltage (in 0.01V) conversion coeff
-#define PROBE_TO_VBAT (450/4096)
+#define PROBE_TO_VBAT (450.0/4096)
 
 #define BATTERY_CHANNEL ADC_CHANNEL_IN1
 #define RCODER_CHANNEL ADC_CHANNEL_IN11


### PR DESCRIPTION
This code lead to a periodic set of the LEDs' color because battery voltage was always seen as equal to zero.